### PR TITLE
fixed credentials bug in cold atom provider

### DIFF
--- a/test/test_cold_atom_provider.py
+++ b/test/test_cold_atom_provider.py
@@ -22,13 +22,18 @@ class TestHeidelbergProvider(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
+
+        # create directory for credentials if it doesn't already exist
+        self.path = os.path.join(os.path.expanduser("~"), ".qiskit")
+        self.path_exists = os.path.isdir(self.path)
+        if not self.path_exists:
+            os.mkdir(self.path)
+
         # Store some credentials
         self.username = "test_user"
         self.token = "test_token"
         self.url = "http://localhost:9000/shots"
-        self.filename = os.path.join(
-            os.path.expanduser("~"), ".qiskit", "cold_atom_provider_test"
-        )
+        self.filename = os.path.join(self.path, "cold_atom_provider_test")
 
     def test_credential_management(self):
         """Test the management of locally stored credential data"""
@@ -99,3 +104,5 @@ class TestHeidelbergProvider(QiskitTestCase):
     def tearDown(self):
         super().tearDown()
         os.remove(self.filename)
+        if not self.path_exists:
+            os.rmdir(self.path)


### PR DESCRIPTION
### Summary

This PR fixes a minor bug in the `test_cold_atom_provider.py` test. 

This test creates (and finally removes again) some mock credentials in a local folder `user/.qiskit`, which is also where the IBMQ credentials are saved. 

Previously these test failed when the `user/.qiskit` directory did not exist. This is fixed now by creating this directory before the tests (if it doesn't already exist). 