### PR TITLE
Improve documentation for backends

### DIFF
--- a/qiskit_cold_atom/fermions/fermion_simulator_backend.py
+++ b/qiskit_cold_atom/fermions/fermion_simulator_backend.py
@@ -30,10 +30,10 @@ from qiskit_cold_atom.circuit_to_cold_atom import validate_circuits
 
 
 class FermionSimulator(BaseFermionBackend):
-    """A simulator to simulate fermionic circuits.
+    """A simulator to simulate general fermionic circuits.
 
     This general fermion simulator backend simulates fermionic circuits with gates that have
-    generators described by Fermionic Hamiltonians. It computes the statevector and unitary
+    generators described by fermionic Hamiltonians. It computes the statevector and unitary
     of a circuit and simulates measurements.
     """
 

--- a/qiskit_cold_atom/providers/cold_atom_provider.py
+++ b/qiskit_cold_atom/providers/cold_atom_provider.py
@@ -26,6 +26,9 @@ from qiskit.providers.providerutils import filter_backends
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit_cold_atom.exceptions import QiskitColdAtomError
 
+from qiskit_cold_atom.fermions import FermionSimulator
+from qiskit_cold_atom.spins import SpinSimulator
+
 from qiskit_cold_atom.providers.fermionic_tweezer_backend import (
     FermionicTweezerSimulator,
 )
@@ -77,6 +80,8 @@ class ColdAtomProvider(Provider):
 
         # Populate the list of backends with the local simulators
         backends = [
+            FermionSimulator(provider=self),
+            SpinSimulator(provider=self),
             FermionicTweezerSimulator(provider=self),
             CollectiveSpinSimulator(provider=self),
         ]

--- a/qiskit_cold_atom/providers/collective_spin_backend.py
+++ b/qiskit_cold_atom/providers/collective_spin_backend.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Backend to simulate collective spin experiments."""
+"""Mock backend to simulate collective spin experiments."""
 
 from typing import Optional
 
@@ -20,7 +20,8 @@ from qiskit_cold_atom.spins.spin_simulator_backend import SpinSimulator
 
 
 class CollectiveSpinSimulator(SpinSimulator):
-    """Simulator backend of a collective spin system of trapped BECs in optical tweezers."""
+    """Mock backend of a spin device with collective spins of trapped BECs in optical tweezers.
+    For a general spin simulator backend, use the SpinSimulator base class."""
 
     def __init__(self, n_tweezers: int = 3, provider: Optional[Provider] = None):
         """Create a new collective spin simulator backend.

--- a/qiskit_cold_atom/providers/collective_spin_backend.py
+++ b/qiskit_cold_atom/providers/collective_spin_backend.py
@@ -20,8 +20,13 @@ from qiskit_cold_atom.spins.spin_simulator_backend import SpinSimulator
 
 
 class CollectiveSpinSimulator(SpinSimulator):
-    """Mock backend of a spin device with collective spins of trapped BECs in optical tweezers.
-    For a general spin simulator backend, use the SpinSimulator base class."""
+    """Emulator backend of a spin device with collective spins of trapped BECs in optical tweezers.
+    
+    This backend will define a configuration with a set of supported gates and a line coupling map.
+    At instantiation users can chose the length of the coupling map which by default is three. This 
+    backend is intended to be a realistic representation of a collective spin experiment with BECs. 
+    For a general spin simulator backend, use the SpinSimulator base class.
+    """
 
     def __init__(self, n_tweezers: int = 3, provider: Optional[Provider] = None):
         """Create a new collective spin simulator backend.

--- a/qiskit_cold_atom/providers/collective_spin_backend.py
+++ b/qiskit_cold_atom/providers/collective_spin_backend.py
@@ -21,10 +21,10 @@ from qiskit_cold_atom.spins.spin_simulator_backend import SpinSimulator
 
 class CollectiveSpinSimulator(SpinSimulator):
     """Emulator backend of a spin device with collective spins of trapped BECs in optical tweezers.
-    
+
     This backend will define a configuration with a set of supported gates and a line coupling map.
-    At instantiation users can chose the length of the coupling map which by default is three. This 
-    backend is intended to be a realistic representation of a collective spin experiment with BECs. 
+    At instantiation users can chose the length of the coupling map which by default is three. This
+    backend is intended to be a realistic representation of a collective spin experiment with BECs.
     For a general spin simulator backend, use the SpinSimulator base class.
     """
 

--- a/qiskit_cold_atom/providers/collective_spin_backend.py
+++ b/qiskit_cold_atom/providers/collective_spin_backend.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Mock backend to simulate collective spin experiments."""
+"""Backend to emulate collective spin experiments."""
 
 from typing import Optional
 

--- a/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
+++ b/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
@@ -10,13 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Backend to simulate fermionic tweezer experiments."""
+"""Mock backend to simulate fermionic tweezer experiments."""
 
 from qiskit_cold_atom.fermions.fermion_simulator_backend import FermionSimulator
 
 
 class FermionicTweezerSimulator(FermionSimulator):
-    """simulator backend of a fermionic hardware with four tweezer sites that uses two spin species"""
+    """Mock backend of a fermionic device with four tweezer sites that uses two spin species.
+    For a general fermionic simulator backend, use the FermionSimulator base class."""
 
     def __init__(self, n_tweezers: int = 4, provider=None):
         """Create a new fermionic tweezer simulator backend.
@@ -43,7 +44,7 @@ class FermionicTweezerSimulator(FermionSimulator):
             "simulator": True,
             "local": True,
             "coupling_map": None,
-            "description": "simulator of a fermionic tweezer hardware. The first half of wires in a "
+            "description": "Mock backend of a fermionic tweezer hardware. The first half of wires in a "
             "circuit denote the occupations of the spin-up fermions and the last half "
             "of wires denote the spin-down fermions",
             "basis_gates": [

--- a/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
+++ b/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
@@ -16,8 +16,13 @@ from qiskit_cold_atom.fermions.fermion_simulator_backend import FermionSimulator
 
 
 class FermionicTweezerSimulator(FermionSimulator):
-    """Mock backend of a fermionic device with four tweezer sites that uses two spin species.
-    For a general fermionic simulator backend, use the FermionSimulator base class."""
+    """Emulator backend of a fermionic device with n tweezer sites that uses two spin species.
+    
+    This backend will define a configuration with a set of supported gates and a line coupling map.
+    At instantiation users can chose the length of the coupling map which by default is four sites.
+    This backend is intended to be a realistic representation of a ferminoic tweezer experiment.
+    For a general fermionic simulator backend, use the FermionSimulator base class.
+    """
 
     def __init__(self, n_tweezers: int = 4, provider=None):
         """Create a new fermionic tweezer simulator backend.

--- a/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
+++ b/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Mock backend to simulate fermionic tweezer experiments."""
+"""Backend to emulate fermionic tweezer experiments."""
 
 from qiskit_cold_atom.fermions.fermion_simulator_backend import FermionSimulator
 

--- a/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
+++ b/qiskit_cold_atom/providers/fermionic_tweezer_backend.py
@@ -17,7 +17,7 @@ from qiskit_cold_atom.fermions.fermion_simulator_backend import FermionSimulator
 
 class FermionicTweezerSimulator(FermionSimulator):
     """Emulator backend of a fermionic device with n tweezer sites that uses two spin species.
-    
+
     This backend will define a configuration with a set of supported gates and a line coupling map.
     At instantiation users can chose the length of the coupling map which by default is four sites.
     This backend is intended to be a realistic representation of a ferminoic tweezer experiment.

--- a/qiskit_cold_atom/spins/spin_simulator_backend.py
+++ b/qiskit_cold_atom/spins/spin_simulator_backend.py
@@ -32,9 +32,10 @@ from qiskit_cold_atom.circuit_to_cold_atom import validate_circuits
 
 
 class SpinSimulator(BaseSpinBackend):
-    """
-    A general spin simulator backend that simulates circuits with gates that have
-    generators described by spin Hamiltonians. Computes the statevector and unitary
+    """A simulator to simulate general spin circuits.
+
+    This general spin simulator backend simulates spin circuits with gates that have
+    generators described by spin Hamiltonians. It computes the statevector and unitary
     of a circuit and simulates measurements.
     """
 


### PR DESCRIPTION
### Summary
This PR improves the distinction between the general-purpose simulator backends for spin and fermionic circuits, and the  mock backends that simulates a real device with sophisticated configuration. 

### Details and comments
Besides slight changes to some docstrings, the `FermionSimulator` and `SpinSimulator` general backends are now also added to the default backends of the provider, so that users don't miss these backends when they check the provider for available backends in their workflow. 


