### PR TITLE
Save account fix

### DIFF
--- a/qiskit_cold_atom/providers/cold_atom_provider.py
+++ b/qiskit_cold_atom/providers/cold_atom_provider.py
@@ -177,6 +177,10 @@ class ColdAtomProvider(Provider):
             overwrite: If true, will overwrite any credentials already stored on disk
             filename: Full path to the credentials file. If ``None``, the default
                 location is used (``$HOME/.qiskit/cold_atom_credentials``).
+
+        Raises:
+            OSError: If there is a race condition when creating the directory for the
+                credentials if it does not already exist.
         """
         if isinstance(url, str):
             url = [url]

--- a/qiskit_cold_atom/providers/cold_atom_provider.py
+++ b/qiskit_cold_atom/providers/cold_atom_provider.py
@@ -17,6 +17,7 @@ import warnings
 import json
 from configparser import ConfigParser, ParsingError
 from typing import Callable, Dict, Optional, Union, List
+import errno
 
 import requests
 
@@ -193,6 +194,12 @@ class ColdAtomProvider(Provider):
 
             if credentials_present and not overwrite:
                 warnings.warn("Credentials already present. Set overwrite=True to overwrite.")
+        else:
+            try:
+                os.makedirs(os.path.dirname(filename))
+            except OSError as exc:  # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise
 
         if not credentials_present or overwrite:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug where `save_account` fails if the .qiskit folder is not present.

### Details and comments

This was fixed by adding code to create the folder and file for the credentials if they do not exist.
