### PR TITLE
Make compatible with current qiskit nature 0.4.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,7 +137,7 @@ numfig_format = {
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/qiskit_cold_atom/fermions/fermion_circuit_solver.py
+++ b/qiskit_cold_atom/fermions/fermion_circuit_solver.py
@@ -151,7 +151,7 @@ class FermionCircuitSolver(BaseCircuitSolver):
 
         embedded_op_list = []
 
-        for partial_label, factor in operator.to_list():
+        for partial_label, factor in operator.to_list(display_format="dense"):
 
             full_label = ["I"] * num_wires
 
@@ -161,7 +161,7 @@ class FermionCircuitSolver(BaseCircuitSolver):
 
             embedded_op_list.append(("".join(full_label), factor))
 
-        return FermionicOp(embedded_op_list)
+        return FermionicOp(embedded_op_list, display_format="dense")
 
     def _check_conservations(self, circuit: QuantumCircuit) -> Tuple[bool, bool]:
         """

--- a/qiskit_cold_atom/fermions/fermion_simulator_backend.py
+++ b/qiskit_cold_atom/fermions/fermion_simulator_backend.py
@@ -20,9 +20,9 @@ import datetime
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit.providers.aer import AerJob
 from qiskit import QuantumCircuit
 from qiskit.result import Result
+from qiskit_aer import AerJob
 
 from qiskit_cold_atom.fermions.fermion_circuit_solver import FermionCircuitSolver
 from qiskit_cold_atom.fermions.base_fermion_backend import BaseFermionBackend

--- a/qiskit_cold_atom/spins/spin_simulator_backend.py
+++ b/qiskit_cold_atom/spins/spin_simulator_backend.py
@@ -21,10 +21,10 @@ import datetime
 
 from qiskit.providers.models import BackendConfiguration
 from qiskit.providers import Options
-from qiskit.providers.aer import AerJob
 from qiskit import QuantumCircuit
 from qiskit.result import Result
 from qiskit.circuit.measure import Measure
+from qiskit_aer import AerJob
 
 from qiskit_cold_atom.spins.spin_circuit_solver import SpinCircuitSolver
 from qiskit_cold_atom.spins.base_spin_backend import BaseSpinBackend

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy>=1.17
 scipy>=1.4
 requests>=2.25.1
 qiskit-terra>= 0.17.1
-qiskit-nature>=0.1.3
+qiskit-nature>=0.4.4
 qiskit-aer>=0.8.0
 matplotlib>=3.3

--- a/test/test_fermion_circuit_solver.py
+++ b/test/test_fermion_circuit_solver.py
@@ -85,7 +85,8 @@ class TestFermionCircuitSolver(QiskitTestCase):
             embedded_op = self.solver1._embed_operator(fer_op, num_wires, qargs)
             target_op = FermionicOp("+_1 -_3", register_length=4)
             self.assertTrue(
-                set(embedded_op.reduce().to_list()) == set(target_op.reduce().to_list())
+                set(embedded_op.simplify().to_list(display_format="dense"))
+                == set(target_op.simplify().to_list(display_format="dense"))
             )
 
     def test_conservation_checks(self):
@@ -132,7 +133,7 @@ class TestFermionCircuitSolver(QiskitTestCase):
         with self.subTest("check dimensionality of operator"):
             self.solver2.preprocess_circuit(circ)
             fer_op_wrong = FermionicOp("+-I")
-            fer_op_correct = FermionicOp("+-II")
+            fer_op_correct = FermionicOp("+-II", register_length=4)
             with self.assertRaises(QiskitColdAtomError):
                 self.solver2.operator_to_mat(fer_op_wrong)
             self.solver2.operator_to_mat(fer_op_correct)
@@ -217,7 +218,10 @@ class TestFermionCircuitSolver(QiskitTestCase):
                 FermionicOp([("NINI", 1), ("ININ", 1)]),
             ]
             for i, op in enumerate(operators):
-                self.assertEqual(set(op.reduce().to_list()), set(target[i].reduce().to_list()))
+                self.assertEqual(
+                    set(op.simplify().to_list(display_format="dense")),
+                    set(target[i].simplify().to_list(display_format="dense")),
+                )
 
     def test_call_method(self):
         """test the call method inherited form BaseCircuitSolver that simulates a circuit"""

--- a/test/test_fermion_simulator_backend.py
+++ b/test/test_fermion_simulator_backend.py
@@ -15,9 +15,9 @@
 from time import sleep
 import numpy as np
 
+from qiskit_aer import AerJob
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.providers import JobStatus
-from qiskit.providers.aer import AerJob
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase
 

--- a/test/test_spin_circuit_solver.py
+++ b/test/test_spin_circuit_solver.py
@@ -61,7 +61,7 @@ class TestSpinCircuitSolver(QiskitTestCase):
             embedded_op = self.solver._embed_operator(spin_op, num_wires, qargs)
             target_op = SpinOp("+_1 -_3", spin=3 / 2, register_length=4)
             self.assertTrue(
-                set(embedded_op.reduce().to_list()) == set(target_op.reduce().to_list())
+                set(embedded_op.simplify().to_list()) == set(target_op.simplify().to_list())
             )
 
     def test_preprocess_circuit(self):
@@ -129,7 +129,7 @@ class TestSpinCircuitSolver(QiskitTestCase):
             ]
 
             for i, op in enumerate(operators):
-                self.assertEqual(set(op.reduce().to_list()), set(target[i].reduce().to_list()))
+                self.assertEqual(set(op.simplify().to_list()), set(target[i].simplify().to_list()))
 
     def test_call_method(self):
         """test the call method inherited form BaseCircuitSolver that simulates a circuit"""
@@ -216,13 +216,13 @@ class TestSpinCircuitSolver(QiskitTestCase):
             self.assertTrue(simulation["counts"], {"0 2": 1, "0 0": 1, "0 3": 1, "0 1": 2})
 
         with self.subTest("check equivalence to qubits for spin-1/2"):
-            from qiskit import Aer
+            from qiskit_aer import AerSimulator
 
             qubit_circ = QuantumCircuit(2)
             qubit_circ.rx(np.pi / 2, [0])
             qubit_circ.rz(-np.pi / 2, [0, 1])
             qubit_circ.save_unitary()
-            qubit_backend = Aer.get_backend("aer_simulator")
+            qubit_backend = AerSimulator()
             job = qubit_backend.run(qubit_circ)
             qubit_unitary = job.result().get_unitary()
 

--- a/test/test_spin_simulator_backend.py
+++ b/test/test_spin_simulator_backend.py
@@ -17,9 +17,9 @@ import numpy as np
 
 from qiskit import QuantumCircuit
 from qiskit.providers import JobStatus
-from qiskit.providers.aer import AerJob
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase
+from qiskit_aer import AerJob
 
 from qiskit_cold_atom.exceptions import QiskitColdAtomError
 from qiskit_cold_atom.spins import SpinSimulator


### PR DESCRIPTION
### Summary
This PR updates the parsing of Fermionic and Spin operators to the syntax of the current version of qiskit nature (0.4.5)

### List of changes
- replace deprecated `.reduce()` method of `FermionicOp` and `SpinOp` with `.simplify()`
- specify dense labels when converting a `FermionicOp` to a list via `to_list()`
- specify language in the docs configuration
- import aer-related classes directly from qiskit-aer instead through terra.
